### PR TITLE
Add ICML 2026 papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Welcome to follow and star!
     - [Advantage](#advantage)
   - [Papers](#papers)
     - [Arxiv](#arxiv)
+    - [ICML 2026](#icml-2026)
     - [NeurIPS 2025](#neurips-2025)
     - [ICML 2025](#icml-2025)
     - [ICLR 2025](#iclr-2025)
@@ -197,6 +198,38 @@ format:
   - Key: Goal-Conditioned Imitation Learning, Robotics, Classifier-free
   - ExpEnv: CALVIN, Block-Push, Relay Kitchen
 
+
+### ICML 2026
+
+- [Reparameterization Flow Policy Optimization](https://arxiv.org/abs/2602.03501)
+  - Hai Zhong, Zhuoran Li, Xun Wang, Longbo Huang
+  - Key: flow policy optimization, reparameterization policy gradient, stability regularization, exploration regularization
+  - ExpEnv: locomotion and manipulation tasks with rigid and soft bodies under both state and visual inputs
+
+- [Mean Flow Policy Optimization](https://arxiv.org/abs/2604.14698)
+  - Xiaoyi Dong, Xi Sheryl Zhang, Jian Cheng
+  - Key: mean-flow policies, online RL, maximum-entropy RL, efficient flow-based policy optimization
+  - ExpEnv: MuJoCo and DeepMind Control Suite benchmarks
+
+- [DADP: Domain Adaptive Diffusion Policy](https://arxiv.org/abs/2602.04037)
+  - Pengcheng Wang, Qinghang Liu, Haotian Lin, Yiheng Li, Guojian Zhan, Masayoshi Tomizuka, Yixiao Wang
+  - Key: domain-adaptive diffusion policy, disentangled domain representation, zero-shot adaptation, diffusion injection
+  - ExpEnv: domain-generalization benchmarks across locomotion and manipulation tasks
+
+- [PromptRL: Prompt Matters in RL for Flow-Based Image Generation](https://arxiv.org/abs/2602.01382)
+  - Fu-Yun Wang, Han Zhang, Michael Gharbi, Hongsheng Li, Taesung Park
+  - Key: flow-based image generation, RL post-training, prompt refinement, prompt robustness
+  - ExpEnv: GenEval, OCR accuracy, PickScore, and FLUX.1-Kontext image-editing reward evaluations
+
+- [FAIL: Flow Matching Adversarial Imitation Learning for Image Generation](https://arxiv.org/abs/2602.12155)
+  - Yeyao Ma, Chen Li, Xiaosong Zhang, Han Hu, Weidi Xie
+  - Key: adversarial imitation learning, flow matching, reward-free alignment, low-variance pathwise gradients
+  - ExpEnv: prompt-following and aesthetic benchmarks, plus discrete image and video generation settings with FLUX fine-tuning
+
+- [Advantage Weighted Matching: Aligning RL with Pretraining in Diffusion Models](https://arxiv.org/abs/2509.25050)
+  - Shuchen Xue, Chongjian Ge, Shilong Zhang, Yichen Li, Zhi-Ming Ma
+  - Key: advantage-weighted matching, diffusion RL, score/flow matching alignment, lower-variance policy gradients
+  - ExpEnv: GenEval, OCR, and PickScore benchmarks on Stable Diffusion 3.5 Medium and FLUX
 
 ### NeurIPS 2025
 


### PR DESCRIPTION
Add 6 ICML 2026 accepted papers to the Diffusion RL awesome list.\n\n- [Reparameterization Flow Policy Optimization](https://arxiv.org/abs/2602.03501)\n- [Mean Flow Policy Optimization](https://arxiv.org/abs/2604.14698)\n- [DADP: Domain Adaptive Diffusion Policy](https://arxiv.org/abs/2602.04037)\n- [PromptRL: Prompt Matters in RL for Flow-Based Image Generation](https://arxiv.org/abs/2602.01382)\n- [FAIL: Flow Matching Adversarial Imitation Learning for Image Generation](https://arxiv.org/abs/2602.12155)\n- [Advantage Weighted Matching: Aligning RL with Pretraining in Diffusion Models](https://arxiv.org/abs/2509.25050)