### PR TITLE
add: add VeRL-Omni to Codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,13 @@ format:
   - Key: Reinforcement Learning, Generative Model, Diffusion Model, Flow Model
   - Code: [official](https://github.com/CleanDiffuserTeam/CleanDiffuser)
 
+- [VeRL-Omni](https://github.com/verl-project/verl-omni)
+  - Yongxiang Huang and Cheung Kawai and Jingan Zhou and Yingshu Chen and openYuanrong Team and Xibin Wu
+  - Publisher: GitHub
+  - Key: Reinforcement Learning, Multimodal Generation, Diffusion Model, Flow Model, Omni-Modality
+  - Code: [official](https://github.com/verl-project/verl-omni)
+  - Docs: [website](https://verl-omni.readthedocs.io/en/latest/index.html)
+
 ## Contributing
 
 Our purpose is to make this repo even better. If you are interested in contributing, please refer to [HERE](CONTRIBUTING.md) for instructions in contribution.


### PR DESCRIPTION
## Summary
- Add [VeRL-Omni](https://github.com/verl-project/verl-omni) to the **Codebase** section.
- VeRL-Omni is an open-source multimodal RL training framework for diffusion and omni-modality models (built on verl), with FlowGRPO / DanceGRPO-style recipes and docs.

## Why this fits
This repo tracks Diffusion Model in RL resources and already lists related codebases (GenerativeRL, CleanDiffuser). VeRL-Omni focuses on RL post-training for diffusion generative models (image/video) and related flow-matching recipes, so it belongs under Codebase.

## Test plan
- [x] Confirm no existing open PR already adds VeRL-Omni
- [x] Entry follows the existing Codebase formatting convention
- [ ] Maintainer review


Made with [Cursor](https://cursor.com)